### PR TITLE
Port contact form components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+This repo contains the Next.js migration of the [Digitaltableteur](https://digitaltableteur.com) site.
+It aims to match the Vite production build found at [PetriLahdelma/digitaltableteur](https://github.com/PetriLahdelma/digitaltableteur).
 
 ## Getting Started
 
@@ -34,3 +35,11 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## TODO
+
+- [ ] Port all blog pages and posts from the Vite repository.
+- [ ] Implement CookieConsent banner and Cookie Policy pages.
+- [ ] Add remaining components (ArticleCard, BlogNav, SocialShare, etc.).
+- [ ] Configure ESLint so `npm run lint` passes.
+- [ ] Add automated tests or adapt existing ones from the old repo.

--- a/app/components/Checkbox/Checkbox.module.css
+++ b/app/components/Checkbox/Checkbox.module.css
@@ -1,0 +1,77 @@
+/* stylelint-disable order/properties-order */
+@import url("../../styles/variables.css");
+@import url("../../styles/fonts.css");
+
+.checkboxContainer {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.checkbox {
+  width: 24px;
+  height: 24px;
+  border: 1px solid var(--color-primary);
+  border-radius: 2px;
+  cursor: pointer;
+  appearance: none;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-appearance: none;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -moz-appearance: none;
+  background: var(--color-white);
+  position: relative;
+  transition:
+    border-color 0.2s,
+    background 0.2s;
+}
+
+.checkbox:hover {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px rgb(0 112 243 / 10%);
+}
+
+.checkbox:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px rgb(0 112 243 / 20%);
+}
+
+.checkbox:checked {
+  background-color: var(--color-primary);
+  border: 1px solid var(--color-primary);
+}
+
+.checkbox:checked::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 12px;
+  height: 6px;
+  border-left: 3px solid var(--color-white);
+  border-bottom: 3px solid var(--color-white);
+  transform: translate(-50%, -60%) rotate(-45deg);
+  border-radius: 1px;
+}
+
+.checkbox:indeterminate {
+  background-color: var(--color-primary);
+  border: 1px solid var(--color-primary);
+}
+
+.checkbox:indeterminate::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 12px;
+  height: 3px;
+  background-color: var(--color-white);
+  transform: translate(-50%, -50%);
+}
+
+.label {
+  font-size: 1rem;
+  color: var(--color-primary);
+}

--- a/app/components/Checkbox/Checkbox.stories.tsx
+++ b/app/components/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { Meta, StoryFn } from "@storybook/react-vite";
+import { within, userEvent } from "@storybook/testing-library";
+import Checkbox, { CheckboxProps } from "./Checkbox";
+import { useTranslation } from "react-i18next";
+
+export default {
+  title: "Components/Checkbox",
+  component: Checkbox,
+  argTypes: {
+    label: { control: "text" },
+    checked: { control: "boolean" },
+    indeterminate: { control: "boolean" },
+  },
+} as Meta<CheckboxProps>;
+
+const StoryLabel = ({ tKey }: { tKey: string }) => {
+  const { t } = useTranslation();
+  return <>{t(tKey)}</>;
+};
+
+const Template: StoryFn<CheckboxProps> = (args: CheckboxProps) => (
+  <Checkbox {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  label: <StoryLabel tKey="storyCheckboxDefault" />,
+};
+Default.play = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+  const canvas = within(canvasElement);
+  const checkbox = await canvas.findByLabelText(/default checkbox/i);
+  await userEvent.click(checkbox);
+};
+
+export const Checked = Template.bind({});
+Checked.args = {
+  label: <StoryLabel tKey="storyCheckboxChecked" />,
+  checked: true,
+};
+Checked.play = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+  const canvas = within(canvasElement);
+  await canvas.findByLabelText(/checked checkbox/i);
+};
+
+export const Indeterminate = Template.bind({});
+Indeterminate.args = {
+  label: <StoryLabel tKey="storyCheckboxIndeterminate" />,
+  checked: false,
+  indeterminate: true,
+};
+Indeterminate.play = async ({
+  canvasElement,
+}: {
+  canvasElement: HTMLElement;
+}) => {
+  const canvas = within(canvasElement);
+  await canvas.findByLabelText(/indeterminate checkbox/i);
+};

--- a/app/components/Checkbox/Checkbox.test.tsx
+++ b/app/components/Checkbox/Checkbox.test.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import Checkbox from "./Checkbox";
+
+describe("Checkbox", () => {
+  it("renders label", () => {
+    render(
+      <Checkbox
+        label="Test Checkbox"
+        checked={false}
+        onChange={() => {}}
+        disabled={false}
+      />,
+    );
+    expect(screen.getByLabelText("Test Checkbox")).toBeInTheDocument();
+  });
+
+  it("calls onChange when clicked", () => {
+    const onChange = vi.fn();
+    render(
+      <Checkbox
+        label="Test Checkbox"
+        checked={false}
+        onChange={onChange}
+        disabled={false}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Test Checkbox"));
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("is checked when checked prop is true", () => {
+    render(
+      <Checkbox
+        label="Checked"
+        checked={true}
+        onChange={() => {}}
+        disabled={false}
+      />,
+    );
+    expect(screen.getByLabelText("Checked")).toBeChecked();
+  });
+
+  it("is disabled when disabled prop is true", () => {
+    render(
+      <Checkbox
+        label="Disabled"
+        checked={false}
+        onChange={() => {}}
+        disabled={true}
+      />,
+    );
+    expect(screen.getByLabelText("Disabled")).toBeDisabled();
+  });
+});

--- a/app/components/Checkbox/Checkbox.tsx
+++ b/app/components/Checkbox/Checkbox.tsx
@@ -1,0 +1,77 @@
+import React, { forwardRef, useEffect } from "react";
+import Label from "@dt/Label";
+import styles from "./Checkbox.module.css";
+
+export interface CheckboxProps
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    "onChange" | "checked"
+  > {
+  label?: string;
+  showLabel?: boolean;
+  checked: boolean;
+  indeterminate?: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  id?: string;
+}
+
+const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
+  (
+    {
+      label,
+      showLabel = true,
+      checked,
+      indeterminate,
+      onCheckedChange,
+      disabled = false,
+      ...props
+    },
+    ref,
+  ) => {
+    useEffect(() => {
+      if (ref && typeof ref !== "function" && ref.current) {
+        ref.current.indeterminate = indeterminate || false;
+        ref.current.checked = checked;
+      }
+    }, [indeterminate, checked, ref]);
+
+    const handleClick = () => {
+      if (indeterminate && ref && typeof ref !== "function" && ref.current) {
+        ref.current.indeterminate = false;
+        onCheckedChange(false); // Reset to unchecked when clicked
+      }
+    };
+
+    return (
+      <div className={styles["checkboxContainer"]}>
+        <input
+          id={props.id || "checkbox"}
+          type="checkbox"
+          className={styles.checkbox}
+          ref={ref}
+          checked={checked}
+          onClick={handleClick}
+          onChange={(e) => {
+            const isChecked = e.target.checked;
+            if (onCheckedChange) {
+              onCheckedChange(isChecked);
+            }
+          }}
+          disabled={disabled}
+          {...props}
+        />
+        <Label
+          htmlFor={props.id || "checkbox"}
+          disabled={disabled}
+          className={styles.label}
+        >
+          {showLabel && label}
+        </Label>
+      </div>
+    );
+  },
+);
+
+Checkbox.displayName = "Checkbox";
+
+export default Checkbox;

--- a/app/components/Checkbox/index.ts
+++ b/app/components/Checkbox/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Checkbox";

--- a/app/components/CheckboxGroup/CheckboxGroup.module.css
+++ b/app/components/CheckboxGroup/CheckboxGroup.module.css
@@ -1,0 +1,28 @@
+@import url("../../styles/variables.css");
+@import url("../../styles/fonts.css");
+
+.checkboxGroup {
+  width: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-block: 1rem;
+}
+
+@supports (width: fit-content) {
+  .checkboxGroup {
+    width: fit-content;
+  }
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-left: 1.5rem;
+}
+
+.checkbox {
+  width: 24px;
+  height: 24px;
+}

--- a/app/components/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/app/components/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Meta, StoryFn } from "@storybook/react-vite";
+import { within } from "@storybook/testing-library";
+import CheckboxGroup, { CheckboxGroupProps } from "./CheckboxGroup";
+import { useTranslation } from "react-i18next";
+
+export default {
+  title: "Components/CheckboxGroup",
+  component: CheckboxGroup,
+  argTypes: {
+    label: { control: "text" },
+    options: { control: "object" },
+    id: { control: "text" },
+  },
+} as Meta<CheckboxGroupProps>;
+
+const CheckboxGroupStory: React.FC<CheckboxGroupProps> = (args) => {
+  const { t } = useTranslation();
+  const translatedOptions = args.options?.map((o) => ({
+    ...o,
+    label: t(o.label as string),
+  }));
+  return (
+    <CheckboxGroup
+      {...args}
+      label={t(args.label as string)}
+      options={translatedOptions}
+    />
+  );
+};
+
+const Template: StoryFn<CheckboxGroupProps> = (args: CheckboxGroupProps) => (
+  <CheckboxGroupStory {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  label: "storyCheckboxGroupLabel",
+  options: [
+    { label: "storyCheckboxOption1", value: "option1" },
+    { label: "storyCheckboxOption2", value: "option2" },
+    { label: "storyCheckboxOption3", value: "option3" },
+    { label: "storyCheckboxOption4", value: "option4" },
+    { label: "storyCheckboxOption5", value: "option5" },
+  ],
+};
+Default.play = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+  const canvas = within(canvasElement);
+  await canvas.findByText(/group label/i);
+};

--- a/app/components/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/app/components/CheckboxGroup/CheckboxGroup.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import CheckboxGroup from "./CheckboxGroup";
+
+describe("CheckboxGroup", () => {
+  const options = [
+    { label: "Option 1", value: "option1" },
+    { label: "Option 2", value: "option2" },
+    { label: "Option 3", value: "option3" },
+  ];
+
+  it("renders group label", () => {
+    render(
+      <CheckboxGroup
+        label="Group Label"
+        options={options}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText("Group Label")).toBeInTheDocument();
+  });
+
+  it("renders all options", () => {
+    render(
+      <CheckboxGroup
+        label="Group Label"
+        options={options}
+        onChange={() => {}}
+      />,
+    );
+    options.forEach((opt) => {
+      expect(screen.getByLabelText(opt.label)).toBeInTheDocument();
+    });
+  });
+
+  it("calls onChange when an option is clicked", () => {
+    const onChange = vi.fn();
+    render(
+      <CheckboxGroup
+        label="Group Label"
+        options={options}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Option 2"));
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/app/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/app/components/CheckboxGroup/CheckboxGroup.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useRef, useState, useCallback } from "react";
+import Checkbox from "../Checkbox/Checkbox";
+import GroupLabel from "../GroupLabel/GroupLabel";
+import styles from "./CheckboxGroup.module.css";
+
+export interface CheckboxGroupProps {
+  id?: string;
+  label: string;
+  className?: string;
+  options: { label: string; value: string }[];
+  // eslint-disable-next-line no-unused-vars
+  onChange?: (selectedOptions: string[]) => void;
+}
+
+const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
+  id = "",
+  label,
+  options = [],
+  onChange,
+}) => {
+  const [checkedStates, setCheckedStates] = useState(options.map(() => false));
+
+  const masterCheckboxRef = useRef<HTMLInputElement>(null);
+
+  const updateMasterCheckboxState = useCallback(() => {
+    if (masterCheckboxRef.current) {
+      const allChecked = checkedStates.every((state) => state);
+      const noneChecked = checkedStates.every((state) => !state);
+      masterCheckboxRef.current.indeterminate = !allChecked && !noneChecked;
+      masterCheckboxRef.current.checked = allChecked;
+    }
+  }, [checkedStates]);
+
+  useEffect(() => {
+    updateMasterCheckboxState();
+  }, [updateMasterCheckboxState]);
+
+  const handleMasterCheckboxChange = (checked: boolean) => {
+    const newCheckedStates = options.map(() => checked);
+    setCheckedStates(newCheckedStates);
+
+    if (onChange) {
+      const selectedOptions = newCheckedStates
+        .map((state, index) => (state ? options[index].value : ""))
+        .filter(Boolean);
+      onChange(selectedOptions);
+    }
+  };
+
+  const handleCheckboxChange = (index: number, checked: boolean) => {
+    const newCheckedStates = [...checkedStates];
+    newCheckedStates[index] = checked;
+    setCheckedStates(newCheckedStates);
+
+    if (onChange) {
+      const selectedOptions = newCheckedStates
+        .map((state, index) => (state ? options[index].value : ""))
+        .filter(Boolean);
+      onChange(selectedOptions);
+    }
+
+    // Update master checkbox state
+    if (masterCheckboxRef.current) {
+      const allChecked = newCheckedStates.every((state) => state);
+      const noneChecked = newCheckedStates.every((state) => !state);
+      masterCheckboxRef.current.indeterminate = !allChecked && !noneChecked;
+      masterCheckboxRef.current.checked = allChecked;
+    }
+  };
+
+  return (
+    <div className={styles["checkboxGroup"]}>
+      <GroupLabel htmlFor={`masterCheckbox-${id}`}>{label}</GroupLabel>
+      <Checkbox
+        ref={masterCheckboxRef}
+        label="All"
+        checked={checkedStates.every((state) => state)}
+        onChange={(checked) => handleMasterCheckboxChange(checked)}
+        id={`masterCheckbox-${id}`}
+      />
+      <div className={styles.options}>
+        {options.map((option, index) => {
+          const optionId = `${id || "checkboxgroup"}-option-${option.value || index}`;
+          return (
+            <Checkbox
+              key={option.value}
+              label={option.label}
+              checked={checkedStates[index]}
+              onChange={(checked) => handleCheckboxChange(index, checked)}
+              id={optionId}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default CheckboxGroup;

--- a/app/components/CheckboxGroup/index.ts
+++ b/app/components/CheckboxGroup/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CheckboxGroup";

--- a/app/components/ContactForm/ContactForm.module.css
+++ b/app/components/ContactForm/ContactForm.module.css
@@ -1,0 +1,42 @@
+@import url("../../styles/variables.css");
+@import url("../../styles/fonts.css");
+
+.contactForm {
+  width: 450px;
+  margin: 2rem auto;
+  padding: 1.5rem;
+  background-color: var(--color-light-bg);
+  border: 2px solid var(--color-primary);
+  box-shadow: 0 4px 6px rgb(0 0 0 / 10%);
+}
+
+.formGroup {
+  margin-block: 0.5rem;
+  width: 100%;
+}
+
+.privacyPolicy {
+  font-size: 0.875rem;
+  color: var(--color-primary);
+  text-align: center;
+  margin-block-end: 1.2rem;
+}
+
+.privacyPolicy a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.privacyPolicy a:hover {
+  text-decoration: underline;
+}
+
+.formGroup:last-child {
+  margin-block-end: 0;
+}
+
+label {
+  font-family: var(--primary-body-font, sans-serif);
+  text-align: left;
+  justify-content: flex-start;
+}

--- a/app/components/ContactForm/ContactForm.tsx
+++ b/app/components/ContactForm/ContactForm.tsx
@@ -1,0 +1,210 @@
+import React, { useState } from "react";
+import { send } from "@emailjs/browser";
+import styles from "./ContactForm.module.css";
+import Inputs from "@dt/Inputs";
+import Button from "@dt/Button";
+import CheckboxGroup from "@dt/CheckboxGroup";
+import Modal from "@dt/Modal";
+import TextArea from "@dt/Inputs/TextArea";
+import { useTranslation } from "react-i18next";
+
+const ContactForm = () => {
+  const { t } = useTranslation();
+  const [formData, setFormData] = useState({
+    fullName: "",
+    email: "",
+    phone: "",
+    interest: "",
+    message: "",
+  });
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isErrorOpen, setIsErrorOpen] = useState(false);
+
+  const handleFullNameChange = (value: string | number) => {
+    setFormData({ ...formData, fullName: String(value) });
+  };
+
+  const handleEmailChange = (value: string | number) => {
+    setFormData({ ...formData, email: String(value) });
+  };
+
+  const handlePhoneChange = (value: string | number) => {
+    setFormData({ ...formData, phone: String(value) });
+  };
+
+  const handleMessageChange = (value: string | number) => {
+    setFormData({ ...formData, message: String(value) });
+  };
+
+  const handleInterestChange = (selectedOptions: string[]) => {
+    setFormData({ ...formData, interest: selectedOptions.join(", ") });
+  };
+
+  const SERVICE_ID =
+    process.env.NEXT_PUBLIC_EMAIL_SERVICE_ID || "service_ix55445";
+  const TEMPLATE_ID =
+    process.env.NEXT_PUBLIC_EMAIL_TEMPLATE_ID || "template_bfw826h";
+  const PUBLIC_KEY = process.env.NEXT_PUBLIC_EMAIL_PUBLIC_KEY || "ockSR3pBVF7_k4-Tu";
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const now = new Date();
+    const time = now.toLocaleString(); // You can customize the format if needed
+
+    // Always try to store in MongoDB and handle response
+    fetch("https://digitaltableteursecureproxy.vercel.app/api/save-contact", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: formData.fullName,
+        email: formData.email,
+        phone: formData.phone,
+        interest: formData.interest,
+        message: formData.message,
+        time,
+      }),
+    }).catch((err) => {
+      // eslint-disable-next-line no-console
+      console.error("Failed to save to MongoDB", err);
+      // Do not show error modal for MongoDB failure
+    });
+
+    // Show modal only after successful EmailJS send
+    send(
+      SERVICE_ID,
+      TEMPLATE_ID,
+      {
+        name: formData.fullName,
+        email: formData.email,
+        phone: formData.phone,
+        interest: formData.interest,
+        message: formData.message,
+        time, // Add the current time for EmailJS {{time}}
+      },
+      PUBLIC_KEY,
+    )
+      .then(() => {
+        setIsModalOpen(true);
+        setFormData({
+          fullName: "",
+          email: "",
+          phone: "",
+          interest: "",
+          message: "",
+        });
+      })
+      .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.error("Failed to send message via EmailJS", err);
+        setIsErrorOpen(true);
+      });
+  };
+
+  return (
+    <div className={styles["contactForm"]}>
+      <form onSubmit={handleSubmit}>
+        <div className={styles["formGroup"]}>
+          <Inputs
+            label={t("contactFullName")}
+            type="text"
+            placeholder={t("contactFullNamePlaceholder")}
+            value={formData.fullName}
+            onChange={handleFullNameChange}
+          />
+        </div>
+
+        <div className={styles["formGroup"]}>
+          <Inputs
+            label={t("contactEmail")}
+            type="email"
+            placeholder={t("contactEmailPlaceholder")}
+            value={formData.email}
+            onChange={handleEmailChange}
+          />
+        </div>
+
+        <div className={styles["formGroup"]}>
+          <Inputs
+            label={t("contactPhone")}
+            type="tel"
+            placeholder={t("contactPhonePlaceholder")}
+            value={formData.phone}
+            onChange={handlePhoneChange}
+          />
+        </div>
+
+        <div className={styles["formGroup"]}>
+          <CheckboxGroup
+            className={styles["checkboxGroup"]}
+            label={t("contactInterest")}
+            options={[
+              {
+                label: t("contactInterestBrandStrategy"),
+                value: "brand-strategy",
+              },
+              {
+                label: t("contactInterestDesignCreative"),
+                value: "design-creative",
+              },
+              {
+                label: t("contactInterestDigitalProducts"),
+                value: "digital-products",
+              },
+              {
+                label: t("contactInterestHelpMeChoose"),
+                value: "help-me-choose",
+              },
+            ]}
+            onChange={handleInterestChange}
+          />
+        </div>
+
+        <div className={styles["formGroup"]}>
+          <TextArea
+            label={t("contactMessage")}
+            placeholder={t("contactMessagePlaceholder")}
+            value={formData.message}
+            onChange={handleMessageChange}
+          />
+        </div>
+
+        <div className={styles["formGroup"]}>
+          <p className={styles["privacyPolicy"]}>
+            *{t("contactPrivacyPolicy1")}{" "}
+            <a href="/privacyPolicy">{t("contactPrivacyPolicy2")}</a>.
+          </p>
+          <Button
+            className={styles["submitButton"]}
+            type="submit"
+            variant="primary"
+          >
+            {t("contactSubmit")}
+          </Button>
+        </div>
+      </form>
+      <Modal
+        className={styles["successModal"]}
+        isOpen={isModalOpen}
+        variant="success"
+        title={t("contactSuccessTitle")}
+        onClose={() => {
+          setIsModalOpen(false);
+          window.location.reload();
+        }}
+      >
+        {t("contactSuccessMessage")}
+      </Modal>
+      <Modal
+        className={styles["errorModal"]}
+        isOpen={isErrorOpen}
+        variant="error"
+        title={t("contactErrorTitle")}
+        onClose={() => setIsErrorOpen(false)}
+      >
+        {t("contactErrorMessage")}
+      </Modal>
+    </div>
+  );
+};
+
+export default ContactForm;

--- a/app/components/ContactForm/index.ts
+++ b/app/components/ContactForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ContactForm";

--- a/app/components/GroupLabel/GroupLabel.module.css
+++ b/app/components/GroupLabel/GroupLabel.module.css
@@ -1,0 +1,12 @@
+@import url("../../styles/variables.css");
+@import url("../../styles/fonts.css");
+
+.groupLabel {
+  font-size: 1rem;
+  font-family: Moderat, sans-serif;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem; /* 8px */
+  color: var(--color-primary);
+}

--- a/app/components/GroupLabel/GroupLabel.tsx
+++ b/app/components/GroupLabel/GroupLabel.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import styles from "./GroupLabel.module.css";
+
+interface GroupLabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
+  htmlFor: string;
+  tooltipText?: string;
+  required?: boolean;
+  disabled?: boolean;
+  title?: string; // Add title for browser tooltips
+}
+
+const GroupLabel: React.FC<GroupLabelProps> = ({
+  htmlFor,
+  children,
+  tooltipText,
+  required,
+  disabled = false,
+  title,
+  ...rest
+}) => {
+  return (
+    <label
+      htmlFor={htmlFor}
+      className={`${styles["groupLabel"]} ${disabled ? styles.disabled : ""}`}
+      title={title || tooltipText} // Use title or fallback to tooltipText
+      {...rest}
+    >
+      {children}
+      {required && <span className={styles.required}>*</span>}
+    </label>
+  );
+};
+
+export default GroupLabel;

--- a/app/components/GroupLabel/index.ts
+++ b/app/components/GroupLabel/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./GroupLabel";

--- a/app/components/Inputs/Inputs.module.css
+++ b/app/components/Inputs/Inputs.module.css
@@ -1,0 +1,75 @@
+@import url("../../styles/variables.css");
+@import url("../../styles/fonts.css");
+
+.inputContainer {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+  box-sizing: border-box;
+}
+
+.label {
+  font-size: 1rem;
+  font-family: Moderat, sans-serif;
+  color: var(--color-primary);
+  align-items: flex-start;
+}
+
+.input {
+  margin-block: 0.5rem;
+  padding: 0.5rem;
+  font-size: 1rem;
+  background-color: var(--color-white);
+  border: 1px solid var(--color-primary);
+  color: var(--color-primary);
+  font-family: Moderat, sans-serif;
+  transition: border-color 0.3s;
+  min-height: 2.5rem;
+  box-sizing: border-box;
+  width: 100%;
+}
+
+.errorMessage {
+  font-family: Moderat, sans-serif;
+  font-size: 1rem;
+  color: var(--color-error);
+  margin-top: 0.5rem;
+}
+
+.input::placeholder {
+  color: var(--color-primary);
+  opacity: 0.5;
+  font-style: italic;
+}
+
+.input:focus {
+  border-color: var(--color-primary);
+  border-width: 1px;
+  outline: 2px solid var(--color-primary);
+  box-sizing: border-box;
+}
+
+.error {
+  border-color: var(--color-error);
+  background-color: var(--color-error-bg);
+}
+
+.input.error::placeholder {
+  color: var(--color-error); /* Error color for placeholder */
+}
+
+.input:disabled {
+  cursor: not-allowed;
+  background-color: var(--color-disabled-bg-light);
+  border-color: var(--color-primary-disabled);
+}
+
+.input:disabled::placeholder {
+  color: var(--color-disabled-placeholder);
+}
+
+.masterCheckbox {
+  display: flex;
+  align-items: flex-start;
+  margin-block: 1.5rem;
+}

--- a/app/components/Inputs/Inputs.stories.tsx
+++ b/app/components/Inputs/Inputs.stories.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { Meta, StoryFn } from "@storybook/react-vite";
+import Input from "./Inputs";
+import { within, userEvent } from "@storybook/testing-library";
+import { useTranslation } from "react-i18next";
+
+export default {
+  title: "Components/Inputs",
+  component: Input,
+  argTypes: {
+    type: {
+      control: {
+        type: "select",
+        options: ["text", "number", "email", "password", "search", "select"],
+      },
+    },
+    label: { control: "text" },
+    placeholder: { control: "text" },
+    error: { control: "text" },
+    options: { control: { type: "object" } }, // Fix type mismatch
+  },
+} as Meta;
+
+const InputStory: React.FC<React.ComponentProps<typeof Input>> = (args) => {
+  const { t } = useTranslation();
+  return (
+    <div style={{ maxWidth: "var(--size-width-md)" }}>
+      <Input
+        {...args}
+        label={t(args.label as string)}
+        placeholder={t(args.placeholder as string)}
+        error={args.error ? t(args.error) : undefined}
+      />
+    </div>
+  );
+};
+
+const Template: StoryFn<typeof Input> = (
+  args: React.ComponentProps<typeof Input>,
+) => <InputStory {...args} />;
+
+export const TextInput = Template.bind({});
+TextInput.args = {
+  label: "storyInputTextLabel",
+  type: "text",
+  placeholder: "storyInputTextPlaceholder",
+};
+TextInput.play = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+  const canvas = within(canvasElement);
+  const input = await canvas.findByLabelText(/text input/i);
+  await userEvent.type(input, "Hello");
+};
+
+export const NumberInput = Template.bind({});
+NumberInput.args = {
+  label: "storyInputNumberLabel",
+  type: "number",
+  placeholder: "storyInputNumberPlaceholder",
+};
+
+export const EmailInput = Template.bind({});
+EmailInput.args = {
+  label: "storyInputEmailLabel",
+  type: "email",
+  placeholder: "storyInputEmailPlaceholder",
+};
+
+export const PasswordInput = Template.bind({});
+PasswordInput.args = {
+  label: "storyInputPasswordLabel",
+  type: "password",
+  placeholder: "storyInputPasswordPlaceholder",
+};
+
+export const SearchInput = Template.bind({});
+SearchInput.args = {
+  label: "storyInputSearchLabel",
+  type: "search",
+  placeholder: "storyInputSearchPlaceholder",
+};
+
+export const InputWithError = Template.bind({});
+InputWithError.args = {
+  label: "storyInputErrorLabel",
+  type: "text",
+  placeholder: "storyInputTextPlaceholder",
+  error: "storyInputErrorText",
+};
+
+export const DisabledInput = Template.bind({});
+DisabledInput.args = {
+  label: "storyInputDisabledLabel",
+  type: "text",
+  placeholder: "storyInputDisabledPlaceholder",
+  disabled: true,
+};

--- a/app/components/Inputs/Inputs.tsx
+++ b/app/components/Inputs/Inputs.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from "react";
+import styles from "./Inputs.module.css";
+import Label from "@dt/Label";
+
+interface InputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange"> {
+  label: string;
+  type: "text" | "number" | "email" | "password" | "search" | "tel";
+  value?: string | number;
+  error?: string;
+  // eslint-disable-next-line no-unused-vars
+  onChange?: (value: string | number) => void;
+}
+
+const Input: React.FC<InputProps> = ({
+  label,
+  type,
+  placeholder,
+  value,
+  error,
+  onChange,
+  disabled = false,
+  ...rest
+}) => {
+  const [inputValue, setInputValue] = useState(value || "");
+  const [phoneError, setPhoneError] = useState("");
+
+  const validatePhoneNumber = (phone: string) => {
+    const phoneRegex = /^[0-9+\s]{1}[0-9\s]{0,15}$/;
+    return phoneRegex.test(phone);
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    let newValue: string | number;
+    newValue = type === "number" ? +e.target.value : e.target.value;
+    if (type === "tel") {
+      if (validatePhoneNumber(e.target.value)) {
+        setPhoneError("");
+        setInputValue(e.target.value);
+        if (onChange) onChange(e.target.value);
+      } else {
+        setPhoneError("Invalid phone number format");
+        setInputValue(e.target.value);
+        if (onChange) onChange(e.target.value);
+      }
+    } else {
+      setInputValue(newValue);
+      if (onChange) onChange(newValue);
+    }
+  };
+
+  return (
+    <div className={styles["input-container"]}>
+      <Label
+        htmlFor={label}
+        required={!!error || !!phoneError}
+        tooltipText={error || phoneError}
+        disabled={disabled}
+      >
+        {label}
+      </Label>
+      <input
+        id={label}
+        name={label.replace(/\s+/g, "-").toLowerCase()}
+        className={`${styles.input} ${error || phoneError ? styles.error : ""}`}
+        type={type}
+        placeholder={placeholder}
+        value={inputValue}
+        onChange={handleChange}
+        disabled={disabled}
+        {...rest}
+      />
+      {(error || phoneError) && (
+        <span className={styles["errorMessage"]}>{error || phoneError}</span>
+      )}
+    </div>
+  );
+};
+
+export default Input;

--- a/app/components/Inputs/TextArea.tsx
+++ b/app/components/Inputs/TextArea.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from "react";
+import styles from "./Inputs.module.css";
+import Label from "@dt/Label";
+
+interface TextAreaProps
+  extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, "onChange"> {
+  label: string;
+  value?: string;
+  error?: string;
+  onChange?: (value: string) => void;
+}
+
+const TextArea: React.FC<TextAreaProps> = ({
+  label,
+  placeholder,
+  value = "",
+  error,
+  onChange,
+  disabled = false,
+  rows = 4,
+  ...rest
+}) => {
+  const [textValue, setTextValue] = useState(value);
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setTextValue(e.target.value);
+    if (onChange) onChange(e.target.value);
+  };
+
+  return (
+    <div className={styles["input-container"]}>
+      <Label
+        htmlFor={label}
+        required={!!error}
+        tooltipText={error}
+        disabled={disabled}
+      >
+        {label}
+      </Label>
+      <textarea
+        id={label}
+        className={`${styles.input} ${error ? styles.error : ""}`}
+        placeholder={placeholder}
+        value={textValue}
+        onChange={handleChange}
+        disabled={disabled}
+        rows={rows}
+        {...rest}
+      />
+      {error && <span className={styles["error-message"]}>{error}</span>}
+    </div>
+  );
+};
+
+export default TextArea;

--- a/app/components/Inputs/index.ts
+++ b/app/components/Inputs/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Inputs";

--- a/app/components/Label/Label.module.css
+++ b/app/components/Label/Label.module.css
@@ -1,0 +1,26 @@
+@import url("../../styles/variables.css");
+@import url("../../styles/fonts.css");
+
+.label {
+  font-size: 1rem; /* 16px */
+  font-family: Moderat, sans-serif;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem; /* 8px */
+  color: var(--color-primary);
+}
+
+.label.disabled {
+  color: var(--color-muted-light);
+  cursor: not-allowed;
+}
+
+.required {
+  color: var(--color-error);
+}
+
+.tooltip {
+  font-size: 0.875rem; /* 14px */
+  color: var(--color-muted);
+  margin-left: 0.5rem; /* 8px */
+}

--- a/app/components/Label/Label.stories.tsx
+++ b/app/components/Label/Label.stories.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { Meta, StoryFn } from "@storybook/react-vite";
+import { within, userEvent } from "@storybook/testing-library";
+import Label from "./Label";
+import { useTranslation } from "react-i18next";
+
+export default {
+  title: "Components/Label",
+  component: Label,
+  argTypes: {
+    htmlFor: { control: "text" },
+    children: { control: "text" },
+    tooltipText: { control: "text" },
+    required: { control: "boolean" },
+    disabled: { control: "boolean" },
+  },
+} as Meta;
+
+const LabelStory: React.FC<React.ComponentProps<typeof Label>> = (args) => {
+  const { t } = useTranslation();
+  return <Label {...args}>{t(args.children as string)}</Label>;
+};
+
+const Template: StoryFn<typeof Label> = (
+  args: React.ComponentProps<typeof Label>,
+) => <LabelStory {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  htmlFor: "input-id",
+  children: "storyLabelDefault",
+};
+
+export const WithTooltip = Template.bind({});
+WithTooltip.args = {
+  htmlFor: "input-id",
+  children: "storyLabelWithTooltip",
+  title: "storyLabelTooltip",
+};
+
+export const Required = Template.bind({});
+Required.args = {
+  htmlFor: "input-id",
+  children: "storyLabelRequired",
+  required: true,
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  htmlFor: "input-id",
+  children: "storyLabelDisabled",
+  disabled: true,
+};
+
+Default.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  await canvas.findByText(/default label/i);
+};
+
+WithTooltip.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const label = await canvas.findByText(/label with tooltip/i);
+  await userEvent.hover(label);
+  // Optionally, check for tooltip appearance if implemented
+};
+
+Required.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  await canvas.findByText(/required label/i);
+};
+
+Disabled.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const label = await canvas.findByText(/disabled label/i);
+  // Optionally, check for disabled state if implemented
+};

--- a/app/components/Label/Label.test.tsx
+++ b/app/components/Label/Label.test.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import Label from "./Label";
+
+describe("Label", () => {
+  it("renders children", () => {
+    const { getByText } = render(<Label htmlFor="test-id">Label Text</Label>);
+    expect(getByText("Label Text")).toBeInTheDocument();
+  });
+
+  it("applies htmlFor prop", () => {
+    const { container } = render(<Label htmlFor="input-id">Label</Label>);
+    expect(container.querySelector("label")).toHaveAttribute("for", "input-id");
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <Label htmlFor="test-id" className="custom-class">
+        Label
+      </Label>,
+    );
+    expect(container.firstChild).toHaveClass("custom-class");
+  });
+});

--- a/app/components/Label/Label.tsx
+++ b/app/components/Label/Label.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import styles from "./Label.module.css";
+
+interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
+  htmlFor: string;
+  tooltipText?: string;
+  required?: boolean;
+  disabled?: boolean;
+}
+
+const Label: React.FC<LabelProps> = ({
+  htmlFor,
+  children,
+  className = "",
+  tooltipText,
+  required,
+  disabled = false,
+  title,
+  ...rest
+}) => {
+  return (
+    <label
+      htmlFor={htmlFor}
+      className={[styles.label, disabled ? styles.disabled : "", className]
+        .filter(Boolean)
+        .join(" ")}
+      title={title || tooltipText} // Use title or fallback to tooltipText
+      {...rest}
+    >
+      {children}
+      {required && <span className={styles.required}>*</span>}
+    </label>
+  );
+};
+
+export default Label;

--- a/app/components/Label/index.ts
+++ b/app/components/Label/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Label";

--- a/app/components/Modal/Modal.module.css
+++ b/app/components/Modal/Modal.module.css
@@ -1,0 +1,135 @@
+@import url("../../styles/variables.css");
+@import url("../../styles/fonts.css");
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgb(0 0 0 / 50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background-color: var(--color-white);
+  box-shadow: 0 4px 8px rgb(0 0 0 / 20%);
+  width: 90%;
+  max-width: var(--size-width-lg);
+  display: flex;
+  flex-direction: column;
+}
+
+.modalContent {
+  padding-block-start: 1.5rem;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  padding: 2rem 1.5rem 1rem;
+  align-items: center;
+}
+
+.leftHeader {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+}
+
+.header svg {
+  vertical-align: middle;
+  align-items: center;
+  width: 24px;
+  height: 24px;
+}
+
+.title {
+  font-family: var(--secondary-heading-font, sans-serif);
+  color: var(--color-primary);
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.menu {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-primary);
+  font-size: 1rem;
+  padding: 0;
+}
+
+.content {
+  padding: 0 1.5rem 1rem;
+  font-family: var(--primary-body-font, sans-serif);
+  color: var(--color-primary);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.footer {
+  padding: 1rem 1.5rem 1.5rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.success {
+  border-top: 4px solid var(--color-success);
+  max-width: 30vw;
+}
+
+.error {
+  border-top: 4px solid var(--color-error);
+  max-width: 30vw;
+}
+
+.info {
+  border-top: 4px solid var(--color-info);
+  max-width: 30vw;
+}
+
+.loading {
+  border-top: none;
+  max-width: 30vw;
+}
+
+.loading .content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 180px;
+  text-align: center;
+  gap: 1rem;
+}
+
+.spinner {
+  border: 4px solid var(--color-border-light);
+  border-top: 4px solid var(--color-info);
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/app/components/Modal/Modal.stories.tsx
+++ b/app/components/Modal/Modal.stories.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from "react";
+import { Meta, StoryFn } from "@storybook/react-vite";
+import Modal, { ModalProps } from "./Modal";
+import Button from "@dt/Button";
+import { useTranslation } from "react-i18next";
+import { FaInfoCircle, FaCheckCircle, FaTimesCircle } from "react-icons/fa";
+import { MdOutlineError } from "react-icons/md";
+
+export default {
+  title: "Components/Modal",
+  component: Modal,
+  argTypes: {
+    title: { control: "text" },
+    variant: {
+      control: {
+        type: "select",
+        options: ["default", "success", "error", "loading", "info"],
+      },
+    },
+    icon: {
+      control: {
+        type: "select",
+        options: {
+          None: null,
+          Error: FaTimesCircle({}),
+          Success: FaCheckCircle({}),
+          Info: FaInfoCircle({}),
+        },
+      },
+    },
+    children: { control: "text" },
+    onClose: { action: "closed" },
+  },
+} as Meta;
+
+const Template: StoryFn<ModalProps> = (args: ModalProps) => {
+  const [open, setOpen] = useState(true);
+  const { t } = useTranslation();
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>{t("storyModalOpen")}</Button>
+      <Modal
+        {...args}
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        icon={args.icon}
+        title={t(args.title as string)}
+        /* eslint-disable react/no-children-prop */
+        children={
+          typeof args.children === "string" ? t(args.children) : args.children
+        }
+        /* eslint-enable react/no-children-prop */
+      />
+    </>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  title: "storyModalDefault",
+  variant: "default",
+  icon: null,
+  showCloseIcon: true,
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  variant: "loading",
+  title: "storyModalLoading",
+  children: <p>{"storyModalPleaseWait"}</p>,
+  showCloseIcon: false,
+};
+
+export const ErrorDialog = Template.bind({});
+ErrorDialog.args = {
+  isOpen: true,
+  title: "storyModalErrorTitle",
+  icon: MdOutlineError({ style: { color: "var(--color-error)" } }),
+  variant: "error",
+  children: "storyModalErrorBody",
+  onClose: () => alert("Closed"),
+};
+
+export const SuccessDialog = Template.bind({});
+SuccessDialog.args = {
+  isOpen: true,
+  title: "storyModalSuccessTitle",
+  icon: FaCheckCircle({ style: { color: "var(--color-success)" } }),
+  variant: "success",
+  children: "storyModalSuccessBody",
+  onClose: () => alert("Closed"),
+};
+
+export const InfoDialog = Template.bind({});
+InfoDialog.args = {
+  isOpen: true,
+  title: "storyModalInfoTitle",
+  icon: FaInfoCircle({ style: { color: "var(--color-info)" } }), // Updated icon format with style prop
+  variant: "info",
+  children: "storyModalInfoBody",
+  onClose: () => alert("Closed"),
+};
+
+export const BusyDialog = Template.bind({});
+BusyDialog.args = {
+  variant: "loading",
+  title: "storyModalBusyTitle",
+  children: <p>{"storyModalBusyBody"}</p>,
+  showCloseIcon: false,
+};

--- a/app/components/Modal/Modal.test.tsx
+++ b/app/components/Modal/Modal.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import Modal from "./Modal";
+
+describe("Modal", () => {
+  it("renders children when open", () => {
+    render(
+      <Modal isOpen title="Test Modal">
+        <div>Modal Content</div>
+      </Modal>,
+    );
+    // Search in document.body for modal content (handles portals/overlays)
+    expect(
+      within(document.body).getByText("Modal Content"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render children when closed", () => {
+    const { queryByText } = render(
+      <Modal isOpen={false} title="Test Modal">
+        <div>Modal Content</div>
+      </Modal>,
+    );
+    expect(queryByText("Modal Content")).not.toBeInTheDocument();
+  });
+});

--- a/app/components/Modal/Modal.tsx
+++ b/app/components/Modal/Modal.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { FaTimes } from "react-icons/fa";
+import styles from "./Modal.module.css";
+import Button from "@dt/Button";
+
+export type ModalVariant = "default" | "success" | "error" | "info" | "loading";
+
+export interface ModalProps {
+  /** Controls visibility */
+  isOpen: boolean;
+  /** Title shown in header */
+  title?: string;
+  /** Dialog variant styling */
+  variant?: ModalVariant;
+  /** Optional contextual menu or extra controls */
+  menu?: React.ReactNode;
+  /** Modal content */
+  children?: React.ReactNode;
+  /** Footer content, e.g. actions */
+  footer?: React.ReactNode;
+  /** Close callback */
+  onClose?: () => void;
+  /** Optional icon to display in the header */
+  icon?: React.ReactNode;
+  /** Optional className for additional styling */
+  className?: string;
+  /** Show close icon button in header */
+  showCloseIcon?: boolean;
+}
+
+const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  title,
+  variant = "default",
+  menu,
+  children,
+  footer,
+  onClose,
+  icon,
+  showCloseIcon = true,
+}) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  const renderFooter = () => {
+    if (footer !== undefined) {
+      return footer;
+    }
+    if (variant !== "loading") {
+      return (
+        <Button onClick={onClose} variant="primary">
+          OK
+        </Button>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <div
+      className={styles.overlay}
+      role="dialog"
+      aria-modal="true"
+      {...(title
+        ? { "aria-labelledby": "modal-title" }
+        : { "aria-label": "Dialog" })}
+    >
+      <div className={`${styles.modal} ${styles[variant]}`}>
+        {title && (
+          <div className={styles.header}>
+            <div className={styles.leftHeader}>
+              {icon && <span className={styles.icon}>{icon}</span>}
+              <h2 id="modal-title" className={styles.title}>
+                {title}
+              </h2>
+            </div>
+            {onClose && showCloseIcon && (
+              <button
+                className={styles["closeButton"]}
+                onClick={onClose}
+                aria-label="Close"
+              >
+                {FaTimes({})}
+              </button>
+            )}
+          </div>
+        )}
+        <div className={styles.content}>
+          {variant === "loading" && <div className={styles.spinner} />}
+          {children}
+        </div>
+        {(footer !== undefined || variant !== "loading") && (
+          <div className={styles.footer}>{renderFooter()}</div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/app/components/Modal/index.ts
+++ b/app/components/Modal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Modal";

--- a/app/contact/Contact.module.css
+++ b/app/contact/Contact.module.css
@@ -1,0 +1,69 @@
+@import url("../styles/variables.css");
+@import url("../styles/fonts.css");
+
+.contact {
+  text-align: center;
+  padding: 32px;
+}
+
+.contact h1 {
+  font-family: var(--primary-heading-font, serif);
+  font-size: 5rem;
+  font-weight: var(--primary-heading-weight, 300);
+  margin-block: 2rem 6rem;
+  color: var(--color-primary);
+}
+
+.contact h2 {
+  font-family: var(--secondary-heading-font, sans-serif);
+  font-size: 1.8rem;
+  text-transform: uppercase;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: var(--color-secondary);
+}
+
+.formGroup {
+  margin-bottom: 1.5rem;
+}
+
+.privacyPolicy {
+  font-size: 1.1rem;
+  color: var(--color-gray-medium);
+  text-align: center;
+}
+
+.privacyPolicy a {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.privacyPolicy a:hover {
+  text-decoration: underline;
+}
+
+.contactForm p {
+  font-family: Moderat, sans-serif;
+  font-size: 0.875rem;
+  color: var(--color-gray-medium);
+  text-align: center;
+  margin: 0;
+}
+
+.checkboxGroup {
+  margin-block-start: 1rem;
+}
+
+.contactFormTitle {
+  font-family: var(--secondary-heading-font, sans-serif);
+  text-transform: uppercase;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: var(--color-secondary);
+}
+
+.contactInfo {
+  color: var(--color-primary);
+  margin-block-end: 2rem;
+  font-size: 1rem;
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,3 +1,47 @@
+"use client";
+import React from "react";
+import Head from "next/head";
+import styles from "./Contact.module.css";
+import ContactForm from "@dt/ContactForm";
+import Title from "@dt/Title";
+import Text from "@dt/Text";
+import Link from "@dt/Link";
+import { useTranslation } from "react-i18next";
+
 export default function ContactPage() {
-  return <div>Contact</div>;
+  const { t } = useTranslation();
+  return (
+    <>
+      <Head>
+        <title>{t("contactMetaTitle")}</title>
+        <meta name="description" content={t("contactMetaDescription") ?? ""} />
+        <meta property="og:title" content={t("contactMetaTitle") ?? ""} />
+        <meta
+          property="og:description"
+          content={t("contactMetaDescription") ?? ""}
+        />
+        <meta property="og:image" content="/logo512.png" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={t("contactMetaTitle") ?? ""} />
+        <meta
+          name="twitter:description"
+          content={t("contactMetaDescription") ?? ""}
+        />
+        <meta name="twitter:image" content="/logo512.png" />
+      </Head>
+      <div className={styles.contact}>
+        <Title size="L">{t("contactHeroTitle")}</Title>
+        <Title level={2} size="S" className={styles.contactFormTitle}>
+          {t("contactFormTitle")}
+        </Title>
+        <Text className={styles.contactInfo}>
+          {t("contactInfo")}{" "}
+          <Link size="S" href="mailto:mail@digitaltableteur.com">
+            mail@digitaltableteur.com
+          </Link>
+        </Text>
+        <ContactForm />
+      </div>
+    </>
+  );
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  webpack: (config) => {
+    config.resolve.alias["@dt"] = require("path").resolve(__dirname, "app/components");
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "digitaltableteur",
       "version": "0.1.0",
       "dependencies": {
+        "@emailjs/browser": "^4.4.1",
         "next": "15.3.5",
         "next-i18next": "^15.4.2",
         "react": "^19.0.0",
@@ -25,6 +26,7 @@
         "@types/react-dom": "^19",
         "@vitest/browser": "^3.2.4",
         "@vitest/coverage-v8": "^3.2.4",
+        "eslint": "^9.31.0",
         "playwright": "^1.54.1",
         "storybook": "^9.0.16",
         "typescript": "^5",
@@ -379,6 +381,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@emailjs/browser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@emailjs/browser/-/browser-4.4.1.tgz",
+      "integrity": "sha512-DGSlP9sPvyFba3to2A50kDtZ+pXVp/0rhmqs2LmbMS3I5J8FSOgLwzY2Xb4qfKlOVHh29EAutLYwe5yuEZmEFg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -831,6 +842,213 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
+      "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.31.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.31.0.tgz",
+      "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+      "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.15.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
@@ -2368,6 +2586,13 @@
         "hoist-non-react-statics": "^3.3.0"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mdx": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
@@ -2619,6 +2844,33 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2644,6 +2896,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -2737,6 +2996,17 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.25.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
@@ -2798,6 +3068,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2939,6 +3219,13 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3012,6 +3299,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
@@ -3156,6 +3450,216 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.31.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.31.0.tgz",
+      "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.3.0",
+        "@eslint/core": "^0.15.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.31.0",
+        "@eslint/plugin-kit": "^0.3.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -3168,6 +3672,42 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/estree-walker": {
@@ -3197,6 +3737,40 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/filesize": {
       "version": "10.1.6",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.6.tgz",
@@ -3224,6 +3798,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -3275,6 +3870,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globrex": {
@@ -3379,6 +4000,16 @@
       "integrity": "sha512-3ZlhNoF9yxnM8pa8bWp5120/Ob6t4lVl1l/tbLmkml/ei3ud8IWySCHt2lrY5xWRlSU5D9IV2sm5bEbGuTqwTw==",
       "license": "MIT"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/image-size": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
@@ -3390,6 +4021,33 @@
       },
       "engines": {
         "node": ">=16.x"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/indent-string": {
@@ -3441,6 +4099,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3449,6 +4117,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-wsl": {
@@ -3576,6 +4257,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -3588,6 +4282,27 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -3615,6 +4330,16 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -3623,6 +4348,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lightningcss": {
@@ -3899,6 +4638,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/loupe": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.4.tgz",
@@ -3965,6 +4711,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -4013,6 +4772,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4026,6 +4786,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/next": {
       "version": "15.3.5",
@@ -4116,34 +4883,6 @@
         "react-i18next": ">= 13.5.0"
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -4167,6 +4906,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/p-limit": {
@@ -4207,6 +4964,19 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/path-exists": {
       "version": "5.0.0",
@@ -4280,6 +5050,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/playwright": {
@@ -4358,6 +5129,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -4405,6 +5186,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react": {
@@ -4553,6 +5344,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/rollup": {
@@ -4736,6 +5537,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4941,6 +5743,19 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5265,6 +6080,19 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -5352,6 +6180,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/vite": {
@@ -5654,6 +6492,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@emailjs/browser": "^4.4.1",
     "next": "15.3.5",
     "next-i18next": "^15.4.2",
     "react": "^19.0.0",
@@ -28,6 +29,7 @@
     "@types/react-dom": "^19",
     "@vitest/browser": "^3.2.4",
     "@vitest/coverage-v8": "^3.2.4",
+    "eslint": "^9.31.0",
     "playwright": "^1.54.1",
     "storybook": "^9.0.16",
     "typescript": "^5",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,15 +13,17 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "baseUrl": ".",
     "plugins": [
       {
         "name": "next"
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "@dt/*": ["./app/components/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "temp-digitaltableteur"]
 }


### PR DESCRIPTION
## Summary
- port ContactForm and related UI components
- configure `@dt` alias in Next config and tsconfig
- migrate contact page markup
- document next.js migration and add TODO section
- include emailjs dependency

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npx tsc --noEmit` *(fails to resolve Storybook modules)*

------
https://chatgpt.com/codex/tasks/task_e_68810de5a96c832eae6bb2fe693915da